### PR TITLE
implicit serialization

### DIFF
--- a/libfive/include/libfive/tree/cache.hpp
+++ b/libfive/include/libfive/tree/cache.hpp
@@ -34,6 +34,13 @@ class Cache
 {
     /*  Helper typedef to avoid writing this over and over again  */
     typedef std::shared_ptr<Tree::Tree_> Node;
+    /*
+     *  A Key uniquely identifies an operation Node, so that we can
+     *  deduplicate based on opcode  and arguments
+     */
+    typedef std::tuple<Opcode::Opcode,  /* opcode */
+      Tree::Id,        /* lhs */
+      Tree::Id         /* rhs */ > Key;
 
     /*  Handle to safely access cache  */
     class Handle
@@ -69,7 +76,8 @@ public:
     static const ZPos& ZPrimRef() { return _ZPos; }
 
     const std::map<const Primitive*, std::weak_ptr<Tree::Tree_>> getPrimitives() const { return primitives; }
-
+    const std::map<float, std::weak_ptr<Tree::Tree_>> getConstants() const { return constants; }
+    const std::map<Key, std::weak_ptr<Tree::Tree_>> getOps() const { return ops; }
     Node var();
     Node primitive(const Primitive& prim);
 
@@ -118,13 +126,6 @@ protected:
      */
     Node checkAffine(Opcode::Opcode op, Node a, Node b);
 
-    /*
-     *  A Key uniquely identifies an operation Node, so that we can
-     *  deduplicate based on opcode  and arguments
-     */
-    typedef std::tuple<Opcode::Opcode,  /* opcode */
-                       Tree::Id,        /* lhs */
-                       Tree::Id         /* rhs */ > Key;
     std::map<Key, std::weak_ptr<Tree::Tree_>> ops;
 
     /*  Constants in the tree are uniquely identified by their value  */

--- a/libfive/include/libfive/tree/tree.hpp
+++ b/libfive/include/libfive/tree/tree.hpp
@@ -39,6 +39,11 @@ class Tree
 {
 public:
     /*
+     *  Empty tree constructor
+     */
+    explicit Tree();
+
+    /*
      *  Returns a Tree for the given constant
      */
     Tree(float v);
@@ -176,11 +181,6 @@ public:
     static Tree load(const std::string& filename);
 
 protected:
-    /*
-     *  Empty tree constructor
-     */
-    explicit Tree();
-
     /*
      *  Private constructor
      */


### PR DESCRIPTION
added getConstants and getOps to the Cache

exposed default constructor for the Tree()